### PR TITLE
updates reagarding rectangular tables

### DIFF
--- a/R/loading.R
+++ b/R/loading.R
@@ -314,7 +314,7 @@ load.study.options <- function(data.dir) {
 #' load.tables(data.dir=system.file("extdata", "s_export_CSV-xls_DEM00_20180912-125720.zip", package = "secuTrial"))
 #' ## rectangular table
 #' load.tables(system.file("extdata", "s_export_rt-CSV-xls_DEM00_20181016-151332.zip", package = "secuTrial"),
-#'             is.rt = TRUE, decode.rt.visitlabels = TRUE)
+#'             decode.rt.visitlabels = TRUE)
 #' @export
 #' @seealso read.DB.table, load.table.list (used in dossier-specific packages), load.study.options
 #' @references http://stackoverflow.com/questions/3640925/global-variable-in-r-function

--- a/R/loading.R
+++ b/R/loading.R
@@ -571,7 +571,7 @@ load.tables <- function(data.dir,
 
 
 
-#' Load labels from an export .
+#' Load labels from an export (non rectangular).
 #'
 #' Get a named vector of variable labels.
 #' Uses results of \code{load.study.options} directly - must be run after \code{load.tables} or \code{load.study.options}
@@ -587,6 +587,7 @@ load.tables <- function(data.dir,
 
 load.labels <- function(){
   if(!exists("study.options")) stop("'study.options' not found \nrun load.study.options(...) or load.tables(...)")
+  if(study.options$is.rectangular) stop("load.labels() is not a valid function for rectangular data")
   on.exit(options("stringsAsFactors"))
   if(options()$stringsAsFactors) options(stringsAsFactors = FALSE)
   if(study.options$is.zip){

--- a/man/load.labels.Rd
+++ b/man/load.labels.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/loading.R
 \name{load.labels}
 \alias{load.labels}
-\title{Load labels from an export .}
+\title{Load labels from an export (non rectangular).}
 \usage{
 load.labels()
 }

--- a/man/load.tables.Rd
+++ b/man/load.tables.Rd
@@ -57,7 +57,7 @@ are specified in \code{load.study.options}.
 load.tables(data.dir=system.file("extdata", "s_export_CSV-xls_DEM00_20180912-125720.zip", package = "secuTrial"))
 ## rectangular table
 load.tables(system.file("extdata", "s_export_rt-CSV-xls_DEM00_20181016-151332.zip", package = "secuTrial"),
-            is.rt = TRUE, decode.rt.visitlabels = TRUE)
+            decode.rt.visitlabels = TRUE)
 }
 \references{
 http://stackoverflow.com/questions/3640925/global-variable-in-r-function

--- a/tests/testthat/test-secuTrial.R
+++ b/tests/testthat/test-secuTrial.R
@@ -105,3 +105,18 @@ labs <- load.labels()
 test_that("First label is age", {
   expect_equal(unname(labs["age"]),"Age")
 })
+
+# test rectangular label in study.options
+# non-rect data
+test_that("Data is not rectangular", {
+  expect_false(study.options$is.rectangular)
+})
+# rect data
+load.study.options(data.dir=system.file("extdata", "s_export_rt-CSV-xls_DEM00_20181016-151332.zip", package = "secuTrial"))
+test_that("Data is not rectangular", {
+  expect_true(study.options$is.rectangular)
+})
+
+
+
+


### PR DESCRIPTION
1. load.labels with rectangular data was causing an issue so I added an exception to the function. 
2. Removing deprecated option (is.rt) from example in load.tables.
3. Since correctly registering if the export is rectangular or not is central, I also added two tests to check this.